### PR TITLE
The Proxy annotation uses `SOURCE` retention

### DIFF
--- a/changelog/@unreleased/pr-13.v2.yml
+++ b/changelog/@unreleased/pr-13.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    The Proxy annotation uses `SOURCE` retention
+
+    Annotation processors do not require CLASS retention.
+  links:
+  - https://github.com/palantir/proxy-processor/pull/13

--- a/changelog/@unreleased/pr-13.v2.yml
+++ b/changelog/@unreleased/pr-13.v2.yml
@@ -1,8 +1,6 @@
 type: improvement
 improvement:
   description: |-
-    The Proxy annotation uses `SOURCE` retention
-
-    Annotation processors do not require CLASS retention.
+    The Proxy annotation uses `SOURCE` retention. Annotation processors do not require `CLASS` retention.
   links:
   - https://github.com/palantir/proxy-processor/pull/13

--- a/proxy-annotations/src/main/java/com/palantir/proxy/annotations/Proxy.java
+++ b/proxy-annotations/src/main/java/com/palantir/proxy/annotations/Proxy.java
@@ -40,5 +40,5 @@ import java.lang.annotation.Target;
  */
 @SuppressWarnings("InvalidBlockTag")
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.SOURCE)
 public @interface Proxy {}


### PR DESCRIPTION
Annotation processors do not require CLASS retention.